### PR TITLE
Allow force updating the game speed in dev mode

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1,15 +1,45 @@
-import { Box } from "@chakra-ui/react";
+import { Box, Heading, Select, StackItem, VStack } from "@chakra-ui/react";
 import React from "react";
+import { selectTicksPerDay, updateTicksPerDay } from "../store/gameSlice";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
 import { ColorModeSwitcher } from "./SettingsTab/ColorModeSwitcher";
 
 type Props = {};
 
 const SettingsTab: React.FunctionComponent<Props> = (props) => {
+  const dispatch = useAppDispatch();
+  const ticksPerDay = useAppSelector(selectTicksPerDay);
+
   return (
-    <Box>
-      Update your settings
-      <ColorModeSwitcher />
-    </Box>
+    <VStack align="flex-start" spacing={4}>
+      <StackItem>
+        <Heading as="h2" size="sm" pb={1}>
+          Theme
+        </Heading>
+        <ColorModeSwitcher />
+      </StackItem>
+
+      {process.env.NODE_ENV !== "production" && (
+        <StackItem>
+          <Heading as="h2" size="sm" pb={1}>
+            Ticks per Second (Development Mode)
+          </Heading>
+          <Box>
+            <Select
+              placeholder="Select option"
+              value={ticksPerDay}
+              onChange={(event) => dispatch(updateTicksPerDay(parseInt(event.target.value, 10)))}
+            >
+              <option value={1}>1</option>
+              <option value={2}>2</option>
+              <option value={4}>4</option>
+              <option value={8}>8</option>
+              <option value={16}>16</option>
+            </Select>
+          </Box>
+        </StackItem>
+      )}
+    </VStack>
   );
 };
 

--- a/src/components/SettingsTab/ColorModeSwitcher.tsx
+++ b/src/components/SettingsTab/ColorModeSwitcher.tsx
@@ -1,25 +1,17 @@
 import * as React from "react";
-import { useColorMode, useColorModeValue, IconButton, IconButtonProps } from "@chakra-ui/react";
+import { useColorMode, useColorModeValue, IconButtonProps, Button } from "@chakra-ui/react";
 import { FaMoon, FaSun } from "react-icons/fa";
 
 type ColorModeSwitcherProps = Omit<IconButtonProps, "aria-label">;
 
 export const ColorModeSwitcher: React.FC<ColorModeSwitcherProps> = (props) => {
   const { toggleColorMode } = useColorMode();
-  const text = useColorModeValue("dark", "light");
+  const text = useColorModeValue("Switch to Dark Mode", "Switch to Light Mode");
   const SwitchIcon = useColorModeValue(FaMoon, FaSun);
 
   return (
-    <IconButton
-      size="md"
-      fontSize="lg"
-      variant="ghost"
-      color="current"
-      marginLeft="2"
-      onClick={toggleColorMode}
-      icon={<SwitchIcon />}
-      aria-label={`Switch to ${text} mode`}
-      {...props}
-    />
+    <Button size="md" fontSize="lg" leftIcon={<SwitchIcon />} variant="solid" onClick={toggleColorMode}>
+      {text}
+    </Button>
   );
 };

--- a/src/lib/CurrentStatistics.ts
+++ b/src/lib/CurrentStatistics.ts
@@ -33,7 +33,7 @@ export type CurrentStatistics = {
 
 export const defaultCurrentStatistics: CurrentStatistics = {
   daysElapsed: serializeNumber(0),
-  ticksPerDay: 8,
+  ticksPerDay: 16,
 
   cashAvailable: serializeNumber(1),
   maxCashAvailable: serializeNumber(0),

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -46,6 +46,10 @@ export const gameSlice = createSlice({
       state.currentStatistics = getNextCurrentStatistics(state.currentStatistics, action.payload);
     },
 
+    updateTicksPerDay: (state, action: PayloadAction<number>) => {
+      state.currentStatistics.ticksPerDay = action.payload;
+    },
+
     buyGenerator: (state, action: PayloadAction<GeneratorType>) => {
       const generatorType = action.payload;
 
@@ -90,11 +94,13 @@ export const gameSlice = createSlice({
   },
 });
 
-export const { tick, buyGenerator, buyResearcher, purchaseResearchProject } = gameSlice.actions;
+export const { tick, buyGenerator, buyResearcher, purchaseResearchProject, updateTicksPerDay } = gameSlice.actions;
 
 export const selectGenerators = (state: RootState) => state.game.generators;
 
 export const selectResearchers = (state: RootState) => state.game.researchers;
+
+export const selectTicksPerDay = (state: RootState) => state.game.currentStatistics.ticksPerDay;
 
 export const selectCurrentStatistics = (state: RootState) => state.game.currentStatistics;
 export const selectCashAvailable = (state: RootState) => state.game.currentStatistics.cashAvailable;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,7 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { gameSlice, tick } from "./gameSlice";
 
-const TICKS_PER_SECOND = 8;
+const TICKS_PER_SECOND = 16;
 
 const store = configureStore({
   reducer: {


### PR DESCRIPTION
## Details

- Update the button for theme switching
- Add selector for ticks per second. This allows you to speed up game progression artificially during testing.
- Bump the number of ticks per second so we can go even faster.

## Screenshot

![localhost_3001_(Small Desktop) (1)](https://user-images.githubusercontent.com/1699388/109309917-e4014e00-7811-11eb-876d-44de6342909e.png)
