### PR TITLE
Format numbers with exponents, decimal places

### DIFF
--- a/src/components/GenerationTab.tsx
+++ b/src/components/GenerationTab.tsx
@@ -1,7 +1,7 @@
 import { Button, Heading, StackItem, Text, VStack } from "@chakra-ui/react";
 import React from "react";
 import { canPurchaseGenerator, generatorDescriptions, generatorTypes } from "../lib/Generators";
-import { compare, formatSerializeableBigNumber, multiply, serializeNumber } from "../lib/SerializeableBigNumber";
+import { compare, formatStandardNumber, formatMoney, multiply, serializeNumber } from "../lib/SerializeableBigNumber";
 import { buyGenerator, selectCashAvailable, selectGenerators, selectMaxCashAvailable } from "../store/gameSlice";
 import { useAppSelector, useAppDispatch } from "../store/hooks";
 
@@ -29,14 +29,13 @@ const GenerationTab: React.FunctionComponent<Props> = (props) => {
               {generatorDescription.name} x {generator.numberOwned}
             </Heading>
             <Text pb={2} fontSize="sm" color="gray.400">
-              Generates {formatSerializeableBigNumber(generator.wattsPerDay)} watts per day --{" "}
-              {generatorDescription.colorText}
+              Generates {formatStandardNumber(generator.wattsPerDay)} watts per day -- {generatorDescription.colorText}
             </Text>
             <Button
               onClick={() => dispatch(buyGenerator(generatorType))}
               disabled={!canPurchaseGenerator(cashAvailable, generator)}
             >
-              Buy for ${formatSerializeableBigNumber(generator.nextPurchaseCost)}
+              Buy for ${formatMoney(generator.nextPurchaseCost, true)}
             </Button>
           </StackItem>
         );

--- a/src/components/ResearchTab.tsx
+++ b/src/components/ResearchTab.tsx
@@ -2,7 +2,7 @@ import { Button, Heading, StackItem, VStack, Text } from "@chakra-ui/react";
 import React from "react";
 import { researcherTypes, researcherDescriptions, canPurchaseResearcher, ResearcherType } from "../lib/Researchers";
 import { researchProjects } from "../lib/ResearchProjects";
-import { compare, multiply, serializeNumber, formatSerializeableBigNumber } from "../lib/SerializeableBigNumber";
+import { compare, multiply, serializeNumber, formatStandardNumber, formatMoney } from "../lib/SerializeableBigNumber";
 import {
   selectCashAvailable,
   selectMaxCashAvailable,
@@ -63,14 +63,14 @@ const ResearchTab: React.FunctionComponent<Props> = (props) => {
                   {researcherDescription.name} x {researcher.numberEmployed}
                 </Heading>
                 <Text pb={2} fontSize="sm" color="gray.400">
-                  Generates {formatSerializeableBigNumber(researcher.ideasPerDay)} ideas per day --{" "}
+                  Generates {formatStandardNumber(researcher.ideasPerDay)} ideas per day --{" "}
                   {researcherDescription.colorText}
                 </Text>
                 <Button
                   onClick={() => dispatch(buyResearcher(researcherType))}
                   disabled={!canPurchaseResearcher(cashAvailable, researcher)}
                 >
-                  Hire for ${formatSerializeableBigNumber(researcher.nextPurchaseCost)}
+                  Hire for ${formatMoney(researcher.nextPurchaseCost, true)}
                 </Button>
               </StackItem>
             );
@@ -109,7 +109,7 @@ const ResearchTab: React.FunctionComponent<Props> = (props) => {
                     onClick={() => dispatch(purchaseResearchProject(researchProject.identifier))}
                     disabled={compare(ideasAvailable, researchProject.cost) !== 1}
                   >
-                    Purchase for {formatSerializeableBigNumber(researchProject.cost)} ideas
+                    Purchase for {formatStandardNumber(researchProject.cost)} ideas
                   </Button>
                 </StackItem>
               );

--- a/src/layout/SummaryPane.tsx
+++ b/src/layout/SummaryPane.tsx
@@ -1,6 +1,6 @@
 import { Heading, StackItem, Text, VStack } from "@chakra-ui/react";
 import React from "react";
-import { divide, formatSerializeableBigNumber, multiply, serializeNumber } from "../lib/SerializeableBigNumber";
+import { divide, multiply, serializeNumber, formatStandardNumber, formatMoney } from "../lib/SerializeableBigNumber";
 import { selectCurrentStatistics } from "../store/gameSlice";
 import { useAppSelector } from "../store/hooks";
 
@@ -34,16 +34,16 @@ const SummaryPane: React.FunctionComponent<Props> = (props) => {
           <Heading as="h2" size="sm" pb={1}>
             Time Elapsed
           </Heading>
-          <Text>{formatSerializeableBigNumber(daysElapsed)} days</Text>
+          <Text>{formatStandardNumber(daysElapsed)} days</Text>
         </StackItem>
 
         <StackItem>
           <Heading as="h2" size="sm" pb={1}>
             Funds
           </Heading>
-          <Text pb={1}>${formatSerializeableBigNumber(cashAvailable)}</Text>
+          <Text pb={1}>${formatMoney(cashAvailable)}</Text>
           <Text fontSize="sm" color="gray.400">
-            ${formatSerializeableBigNumber(cashEarnedPerDay)} per day
+            ${formatMoney(cashEarnedPerDay)} per day
           </Text>
         </StackItem>
 
@@ -51,9 +51,9 @@ const SummaryPane: React.FunctionComponent<Props> = (props) => {
           <Heading as="h2" size="sm" pb={1}>
             Power Generation
           </Heading>
-          <Text pb={1}>{formatSerializeableBigNumber(wattsGeneratedPerDay)} watts per day</Text>
+          <Text pb={1}>{formatStandardNumber(wattsGeneratedPerDay)} watts per day</Text>
           <Text fontSize="sm" color="gray.400">
-            ${formatSerializeableBigNumber(pricePerWatt)} per watt
+            ${formatMoney(pricePerWatt)} per watt
           </Text>
         </StackItem>
 
@@ -62,13 +62,13 @@ const SummaryPane: React.FunctionComponent<Props> = (props) => {
             Houses Illuminated
           </Heading>
           <Text pb={1}>
-            {formatSerializeableBigNumber(homesPowered)} / {formatSerializeableBigNumber(homesInPowerGrid)}
+            {formatStandardNumber(homesPowered, 2)} / {formatStandardNumber(homesInPowerGrid)}
           </Text>
           <Text pb={1} color={homesPowered === homesInPowerGrid ? undefined : "red.500"}>
-            {formatSerializeableBigNumber(percentOfHomesPowered)}%
+            {formatStandardNumber(percentOfHomesPowered)}%
           </Text>
           <Text fontSize="sm" color="gray.400">
-            {formatSerializeableBigNumber(wattsUsedPerHomePerDay)} watts used per house per day
+            {formatStandardNumber(wattsUsedPerHomePerDay)} watts used per house per day
           </Text>
         </StackItem>
 
@@ -76,9 +76,9 @@ const SummaryPane: React.FunctionComponent<Props> = (props) => {
           <Heading as="h2" size="sm" pb={1}>
             Research
           </Heading>
-          <Text pb={1}>{formatSerializeableBigNumber(ideasAvailable)} ideas</Text>
+          <Text pb={1}>{formatStandardNumber(ideasAvailable)} ideas</Text>
           <Text fontSize="sm" color="gray.400">
-            {formatSerializeableBigNumber(ideasGeneratedPerDay)} ideas per day
+            {formatStandardNumber(ideasGeneratedPerDay)} ideas per day
           </Text>
         </StackItem>
       </VStack>

--- a/src/lib/SerializeableBigNumber.ts
+++ b/src/lib/SerializeableBigNumber.ts
@@ -39,3 +39,31 @@ export const compare = (a: SerializeableBigNumber, b: SerializeableBigNumber): n
   Decimal.compare(toDecimal(a), toDecimal(b));
 
 export const formatSerializeableBigNumber = (a: SerializeableBigNumber): string => toDecimal(a).toString();
+
+export const formatStandardNumber = (a: SerializeableBigNumber, maxDecimalPlaces: number = 1): string => {
+  const decimal = toDecimal(a);
+
+  if (decimal.lt(new Decimal(10000))) {
+    if (decimal.trunc().eq(decimal)) {
+      return decimal.toFixed(0);
+    } else {
+      return decimal.toFixed(maxDecimalPlaces);
+    }
+  } else {
+    return decimal.toExponential(3);
+  }
+};
+
+export const formatMoney = (a: SerializeableBigNumber, withoutCentsForWholeAmounts: boolean = false): string => {
+  const decimal = toDecimal(a);
+
+  if (decimal.lt(new Decimal(1000))) {
+    if (withoutCentsForWholeAmounts && decimal.trunc().eq(decimal)) {
+      return decimal.toFixed(0);
+    } else {
+      return decimal.toFixed(2);
+    }
+  } else {
+    return decimal.toExponential(3);
+  }
+};


### PR DESCRIPTION
## Details

- Format money with decimal places until we get into exponent territory. Money values that do not change frequently, like purchase price, may drop the cents where possible because it is not used for all resource generators.
- Format other numbers without decimal place where possible, limit the decimal places when needed.
- I don't love the + on the exponent, but it is sufficient for now.

## Screenshots

![localhost_3001_(Small Desktop) (4)](https://user-images.githubusercontent.com/1699388/109401364-3e86d100-791c-11eb-93af-206bb80d9e24.png)