### PR TITLE
Define the set of power generators

### DIFF
--- a/src/components/GenerationTab.tsx
+++ b/src/components/GenerationTab.tsx
@@ -1,6 +1,6 @@
 import { Button, Heading, StackItem, Text, VStack } from "@chakra-ui/react";
 import React from "react";
-import { canPurchaseGenerator, generatorDescriptions, generatorTypes } from "../lib/Generators";
+import { canPurchaseGenerator, defaultGeneratorsState, generatorDescriptions, generatorTypes } from "../lib/Generators";
 import { compare, formatStandardNumber, formatMoney, multiply, serializeNumber } from "../lib/SerializeableBigNumber";
 import { buyGenerator, selectCashAvailable, selectGenerators, selectMaxCashAvailable } from "../store/gameSlice";
 import { useAppSelector, useAppDispatch } from "../store/hooks";
@@ -18,8 +18,9 @@ const GenerationTab: React.FunctionComponent<Props> = (props) => {
       {generatorTypes.map((generatorType) => {
         const generator = generators[generatorType];
         const generatorDescription = generatorDescriptions[generatorType];
+        const baseCost = defaultGeneratorsState[generatorType].nextPurchaseCost;
 
-        if (compare(maxCashAvailable, multiply(serializeNumber(0.75), generatorDescription.baseCost)) === -1) {
+        if (compare(maxCashAvailable, multiply(serializeNumber(0.75), baseCost)) === -1) {
           return null;
         }
 

--- a/src/lib/Generators.test.ts
+++ b/src/lib/Generators.test.ts
@@ -1,18 +1,32 @@
-import {
-  calculateWattsGenerated,
-  canPurchaseGenerator,
-  GeneratorsState,
-  GeneratorState,
-  GeneratorType,
-  generatorTypes,
-  purchaseGenerator,
-} from "./Generators";
+import { canPurchaseGenerator, GeneratorState, GeneratorType, generatorTypes, purchaseGenerator } from "./Generators";
 import { serializeNumber } from "./SerializeableBigNumber";
 
 describe("Generators", () => {
   describe("generatorTypes", () => {
     it("returns the generator types in order of increasing base cost", () => {
-      expect(generatorTypes).toEqual(["hamsters", "pinwheels", "bicycle"]);
+      expect(generatorTypes).toEqual([
+        "hamsters",
+        "pinwheels",
+        "handCrank",
+        "bicycle",
+        "solarPanel",
+        "picoHydro",
+        "biomass",
+        "tidalStream",
+        "solarDish",
+        "ethanol",
+        "smallHydro",
+        "windTurbine",
+        "coal",
+        "oil",
+        "solarPowerTower",
+        "naturalGas",
+        "hydroelectricDam",
+        "nuclearFission",
+        "spaceSolarArray",
+        "nuclearFusion",
+        "dysonSphere",
+      ]);
     });
   });
 
@@ -53,32 +67,7 @@ describe("Generators", () => {
 
     it("updates the nextPurchaseCost", () => {
       const updatedGenerator = purchaseGenerator(GeneratorType.pinwheels, generator);
-      expect(updatedGenerator.nextPurchaseCost).toEqual(serializeNumber(10));
-    });
-  });
-
-  describe("calculateWattsGenerated", () => {
-    const generatorsState: GeneratorsState = {
-      hamsters: {
-        numberOwned: 13,
-        wattsPerDay: serializeNumber(3),
-        nextPurchaseCost: serializeNumber(10),
-      },
-      pinwheels: {
-        numberOwned: 7,
-        wattsPerDay: serializeNumber(11),
-        nextPurchaseCost: serializeNumber(15),
-      },
-      bicycle: {
-        numberOwned: 5,
-        wattsPerDay: serializeNumber(19),
-        nextPurchaseCost: serializeNumber(20),
-      },
-    };
-
-    it("sums the watts per day generated for the different generator types", () => {
-      const result = calculateWattsGenerated(generatorsState);
-      expect(result).toEqual(serializeNumber(13 * 3 + 7 * 11 + 5 * 19));
+      expect(updatedGenerator.nextPurchaseCost).toEqual(serializeNumber(6));
     });
   });
 });

--- a/src/lib/Generators.ts
+++ b/src/lib/Generators.ts
@@ -1,15 +1,34 @@
+import { binomialCostGenerator, linearCostGenerator, trinomialCostGenerator } from "./costGenerator";
 import { add, compare, multiply, SerializeableBigNumber, serializeNumber } from "./SerializeableBigNumber";
 
 export enum GeneratorType {
   hamsters = "hamsters",
   pinwheels = "pinwheels",
+  handCrank = "handCrank",
   bicycle = "bicycle",
+  solarPanel = "solarPanel",
+  picoHydro = "picoHydro",
+  biomass = "biomass",
+  tidalStream = "tidalStream",
+  solarDish = "solarDish",
+  ethanol = "ethanol",
+  smallHydro = "smallHydro",
+  windTurbine = "windTurbine",
+  coal = "coal",
+  oil = "oil",
+  solarPowerTower = "solarPowerTower",
+  naturalGas = "naturalGas",
+  hydroelectricDam = "hydroelectricDam",
+  nuclearFission = "nuclearFission",
+  spaceSolarArray = "spaceSolarArray",
+  nuclearFusion = "nuclearFusion",
+  dysonSphere = "dysonSphere",
 }
 
 export type GeneratorDescription = {
   name: string;
   colorText: string;
-  baseCost: SerializeableBigNumber;
+  baseWattsPerDay: SerializeableBigNumber;
   costOfNthGenerator: (n: number) => SerializeableBigNumber;
 };
 
@@ -21,26 +40,130 @@ export const generatorDescriptions: GeneratorDescriptions = {
   hamsters: {
     name: "Hamster",
     colorText: "Watch those little legs go!",
-    baseCost: serializeNumber(0.25),
-    costOfNthGenerator: (n) => serializeNumber(n * 0.25),
+    baseWattsPerDay: serializeNumber(0.5),
+    costOfNthGenerator: linearCostGenerator(0.25, 0),
   },
   pinwheels: {
     name: "Pinwheel",
     colorText: "One day you'll build a great wind farm.",
-    baseCost: serializeNumber(2),
-    costOfNthGenerator: (n) => serializeNumber(n * 2),
+    baseWattsPerDay: serializeNumber(3),
+    costOfNthGenerator: linearCostGenerator(1, 1),
+  },
+  handCrank: {
+    name: "Hand Crank",
+    colorText: "Skip the gym and make some money.",
+    baseWattsPerDay: serializeNumber(11),
+    costOfNthGenerator: linearCostGenerator(7, 3),
   },
   bicycle: {
     name: "Human-powered Bicycle",
     colorText: "You can make it up the hill, just keep pedaling!",
-    baseCost: serializeNumber(20),
-    costOfNthGenerator: (n) => serializeNumber((n - 1) * 5 + 20),
+    baseWattsPerDay: serializeNumber(127),
+    costOfNthGenerator: linearCostGenerator(31, 23),
+  },
+  solarPanel: {
+    name: "Solar Panel",
+    colorText: "The photo-voltaic cells soak up the sun's rays and turn it into a modest amount of electricity.",
+    baseWattsPerDay: serializeNumber(307),
+    costOfNthGenerator: linearCostGenerator(101, 43),
+  },
+  picoHydro: {
+    name: "Pico Hydro",
+    colorText: "These small power plants generate electricity using water from nearby streams.",
+    baseWattsPerDay: serializeNumber(1669),
+    costOfNthGenerator: linearCostGenerator(569, 83),
+  },
+  biomass: {
+    name: "Biomass Power Plant",
+    colorText: "These power plants burn things like plants, trees, and even garbage to generate electricity.",
+    baseWattsPerDay: serializeNumber(4229),
+    costOfNthGenerator: linearCostGenerator(2143, 257),
+  },
+  tidalStream: {
+    name: "Tidal Stream Generator",
+    colorText: "It's like a wind turbine, for the sea!",
+    baseWattsPerDay: serializeNumber(16_903),
+    costOfNthGenerator: linearCostGenerator(9157, 1409),
+  },
+  solarDish: {
+    name: "Solar Dish",
+    colorText: "A parabolic dish that focuses energy from the sun onto a receiver.",
+    baseWattsPerDay: serializeNumber(69_427),
+    costOfNthGenerator: linearCostGenerator(26_927, 6373),
+  },
+  ethanol: {
+    name: "Ethanol Power Plant",
+    colorText: "A power plant that burns ethanol to generate electricity.",
+    baseWattsPerDay: serializeNumber(251_393),
+    costOfNthGenerator: linearCostGenerator(94583, 18_661),
+  },
+  smallHydro: {
+    name: "Small Hydro",
+    colorText: "A hydroelectric powerplant located on a small river",
+    baseWattsPerDay: serializeNumber(969_503),
+    costOfNthGenerator: binomialCostGenerator(7, 173_431, 22_769),
+  },
+  windTurbine: {
+    name: "Wind Turbine",
+    colorText: "Finally, the wind farm that you've always dreamed of!",
+    baseWattsPerDay: serializeNumber(3_117_467),
+    costOfNthGenerator: binomialCostGenerator(31, 340_801, 83_341),
+  },
+  coal: {
+    name: "Coal Power Plant",
+    colorText: "A power plant that burns coal to generate electricity. This is a bit dirty...",
+    baseWattsPerDay: serializeNumber(12_138_481),
+    costOfNthGenerator: binomialCostGenerator(101, 999_983, 243_197),
+  },
+  oil: {
+    name: "Oil Power Plant",
+    colorText: "A power plant that burns oil to generate electricity.",
+    baseWattsPerDay: serializeNumber(42_666_601),
+    costOfNthGenerator: binomialCostGenerator(569, 2_804_569, 976_909),
+  },
+  solarPowerTower: {
+    name: "Solar Power Tower",
+    colorText: "A collection of mirrors that focus sunlight on a central tower to generate heat.",
+    baseWattsPerDay: serializeNumber(369_671_453),
+    costOfNthGenerator: binomialCostGenerator(2143, 9_009_163, 3_914_269),
+  },
+  naturalGas: {
+    name: "Natural Gas Power Plant",
+    colorText: "A power plant that burns natural gas to generate electricity.",
+    baseWattsPerDay: serializeNumber(2_429_698_879),
+    costOfNthGenerator: binomialCostGenerator(9157, 32_046_979, 15_662_723),
+  },
+  hydroelectricDam: {
+    name: "Hydroelectric Dam",
+    colorText: "A large hydroelectric dam that generates a large amount of power.",
+    baseWattsPerDay: serializeNumber(9_679_695_049),
+    costOfNthGenerator: binomialCostGenerator(26927, 132_045_167, 62_659_657),
+  },
+  nuclearFission: {
+    name: "Nuclear Fission Reactor",
+    colorText: "A power plant that uses controlled nuclear fission reactions to generate electricity.",
+    baseWattsPerDay: serializeNumber(31_679_723_617),
+    costOfNthGenerator: trinomialCostGenerator(7, 94583, 373_202_677, 250_641_211),
+  },
+  spaceSolarArray: {
+    name: "Space Solar Panel Array",
+    colorText: "With nothing in the way, we can generate even more solar power!",
+    baseWattsPerDay: serializeNumber(187_679_724_691),
+    costOfNthGenerator: trinomialCostGenerator(31, 173431, 923_212_441, 1_002_572_119),
+  },
+  nuclearFusion: {
+    name: "Nuclear Fusion Reactor",
+    colorText: "An even more efficient form of nuclear power.",
+    baseWattsPerDay: serializeNumber(969_679_760_479),
+    costOfNthGenerator: trinomialCostGenerator(101, 340801, 2_735_208_481, 4_010_292_701),
+  },
+  dysonSphere: {
+    name: "Dyson Sphere",
+    colorText: "Capture energy from stars across the universe.",
+    baseWattsPerDay: serializeNumber(42_000_000_000_000),
+    costOfNthGenerator: trinomialCostGenerator(569, 999983, 6_135_210_871, 16_041_259_051),
   },
 };
-
-export const generatorTypes = Object.keys(GeneratorType).sort((a, b) =>
-  compare(generatorDescriptions[a as GeneratorType].baseCost, generatorDescriptions[b as GeneratorType].baseCost),
-) as Array<GeneratorType>;
 
 export type GeneratorState = {
   numberOwned: number;
@@ -52,23 +175,21 @@ export type GeneratorsState = {
   [key in GeneratorType]: GeneratorState;
 };
 
-export const defaultGeneratorsState: GeneratorsState = {
-  hamsters: {
-    numberOwned: 0,
-    wattsPerDay: serializeNumber(0.5),
-    nextPurchaseCost: generatorDescriptions.hamsters.baseCost,
+export const defaultGeneratorsState: GeneratorsState = Object.entries(generatorDescriptions).reduce(
+  (acc, [key, value]) => {
+    acc[key as GeneratorType] = {
+      numberOwned: 0,
+      wattsPerDay: value.baseWattsPerDay,
+      nextPurchaseCost: value.costOfNthGenerator(1),
+    };
+    return acc;
   },
-  pinwheels: {
-    numberOwned: 0,
-    wattsPerDay: serializeNumber(2),
-    nextPurchaseCost: generatorDescriptions.pinwheels.baseCost,
-  },
-  bicycle: {
-    numberOwned: 0,
-    wattsPerDay: serializeNumber(10),
-    nextPurchaseCost: generatorDescriptions.pinwheels.baseCost,
-  },
-};
+  {} as GeneratorsState,
+);
+
+export const generatorTypes = Object.entries(defaultGeneratorsState)
+  .sort(([typeA, generatorA], [typeB, generatorB]) => compare(generatorA.nextPurchaseCost, generatorB.nextPurchaseCost))
+  .map(([type, generator]) => type as GeneratorType) as Array<GeneratorType>;
 
 export const canPurchaseGenerator = (cashAvailable: SerializeableBigNumber, generator: GeneratorState): boolean =>
   compare(cashAvailable, generator.nextPurchaseCost) !== -1;

--- a/src/lib/costGenerator.ts
+++ b/src/lib/costGenerator.ts
@@ -1,0 +1,9 @@
+import { serializeNumber } from "./SerializeableBigNumber";
+
+export const linearCostGenerator = (a: number, b: number) => (n: number) => serializeNumber(a * n + b);
+
+export const binomialCostGenerator = (a: number, b: number, c: number) => (n: number) =>
+  serializeNumber(a * n * n + b * n + c);
+
+export const trinomialCostGenerator = (a: number, b: number, c: number, d: number) => (n: number) =>
+  serializeNumber(a * n * n * n + b * n * n + c * n + d);


### PR DESCRIPTION
## Details

- Configure more generators to fill out the game
- Generate the initial state of the generators based on the definitions to prevent typo-related bugs (like the first bicycle has been $2 during development)

## Future work

- The tab content (like where we show the generators list) should scroll independently of the summary area

## Screenshot

![localhost_3000_(Small Desktop) (3)](https://user-images.githubusercontent.com/1699388/109421245-83564a80-79a4-11eb-94c1-5270cc1a3b76.png)
