### PR TITLE
Fix scrolling, settings tab

### DIFF
--- a/src/layout/App.tsx
+++ b/src/layout/App.tsx
@@ -12,14 +12,14 @@ const App: React.FunctionComponent = () => (
       <GameAutosaver />
 
       <Box>
-        <Flex minH="100vh" direction="row" alignItems="stretch">
-          <Box overflow="auto" w={250} p={3}>
+        <Flex minH="100vh" height="100vh" maxH="100vh" direction="row" alignItems="stretch">
+          <Box w={250} p={3} overflowY="auto">
             <SummaryPane />
           </Box>
           <Box>
             <Divider orientation="vertical" />
           </Box>
-          <Box flexGrow={1} overflow="auto">
+          <Box flexGrow={1}>
             <ContentPane />
           </Box>
         </Flex>

--- a/src/layout/App.tsx
+++ b/src/layout/App.tsx
@@ -13,7 +13,7 @@ const App: React.FunctionComponent = () => (
 
       <Box>
         <Flex minH="100vh" height="100vh" maxH="100vh" direction="row" alignItems="stretch">
-          <Box w={250} p={3} overflowY="auto">
+          <Box w={250} p={3} flexShrink={0} overflowY="auto">
             <SummaryPane />
           </Box>
           <Box>

--- a/src/layout/ContentPane.tsx
+++ b/src/layout/ContentPane.tsx
@@ -9,7 +9,7 @@ type Props = {};
 
 const ContentPane: React.FunctionComponent<Props> = (props) => {
   return (
-    <Tabs>
+    <Tabs display="flex" flexDirection="column" maxH="100vh">
       <TabList>
         <Tab>Generation</Tab>
         <Tab>Research</Tab>
@@ -17,7 +17,7 @@ const ContentPane: React.FunctionComponent<Props> = (props) => {
         <Tab>Settings</Tab>
       </TabList>
 
-      <TabPanels>
+      <TabPanels flexGrow={1} overflowY="auto">
         <TabPanel>
           <GenerationTab />
         </TabPanel>


### PR DESCRIPTION
## Details

- Have the content scroll within the tab content area
- Fix the summary pane squishing when viewing settings on small screen sizes

## Screenshots

![192 168 86 27_3000_(Small Desktop)](https://user-images.githubusercontent.com/1699388/109431008-38532c00-79d2-11eb-9021-2d87722703c5.png)

![192 168 86 27_3000_(Small Desktop) (1)](https://user-images.githubusercontent.com/1699388/109431011-39845900-79d2-11eb-857c-dd0df2d0b428.png)
